### PR TITLE
add stalebot workflow to all repositories

### DIFF
--- a/files/.github/workflows/stale.yml
+++ b/files/.github/workflows/stale.yml
@@ -20,6 +20,7 @@ jobs:
         close-issue-message: 'This issue was closed because it is missing author input.'
         stale-issue-label: 'kind/stale'
         any-of-labels: 'need/author-input'
+        exempt-issue-labels: 'need/maintainer-input,need/maintainers-input,need/analysis'
         days-before-issue-stale: 6
         days-before-issue-close: 7
         enable-statistics: true

--- a/files/.github/workflows/stale.yml
+++ b/files/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
         close-issue-message: 'This issue was closed because it is missing author input.'
         stale-issue-label: 'kind/stale'
         any-of-labels: 'need/author-input'
-        exempt-issue-labels: 'need/maintainer-input,need/maintainers-input,need/analysis'
+        exempt-issue-labels: 'need/triage,need/community-input,need/maintainer-input,need/maintainers-input,need/analysis'
         days-before-issue-stale: 6
         days-before-issue-close: 7
         enable-statistics: true

--- a/files/.github/workflows/stale.yml
+++ b/files/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
         stale-issue-message: 'Oops, seems like we needed more information for this issue, please comment with more details or this issue will be closed in 7 days.'
         close-issue-message: 'This issue was closed because it is missing author input.'
         stale-issue-label: 'kind/stale'
-        any-of-labels: 'hint/needs-author-input,need/author-input'
+        any-of-labels: 'need/author-input'
         days-before-issue-stale: 6
         days-before-issue-close: 7
         enable-statistics: true

--- a/github/ipfs/repository_file.json
+++ b/github/ipfs/repository_file.json
@@ -4,5 +4,10 @@
       "branch": "main",
       "content": "./.github/workflows/stale.yml"
     }
+  },
+  "go-ipfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
   }
 }

--- a/github/ipfs/repository_file.json
+++ b/github/ipfs/repository_file.json
@@ -9,5 +9,835 @@
     ".github/workflows/stale.yml": {
       "content": "./.github/workflows/stale.yml"
     }
+  },
+  "2022.ipfs.camp": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "aegir": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "aegir-typedoc-theme": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "apps": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "artwork": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "awesome-ipfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "benchmarks": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "browser-design-guidelines": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "camp": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "camp.ipfs.io": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "choco-go-ipfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ci-helpers": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "community": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "devgrants": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "dir-index-html": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "distributed-wikipedia-mirror": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "distributions": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ecosystem-directory": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "eslint-config-ipfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "fs-repo-migrations": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "gh-issue-form-test": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "github-mgmt": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-bitswap": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-bitswap-priv": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-block-format": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-blockservice": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-bs-sqlite3": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-cid": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-cidutil": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-dag-store": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-dagwriter": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-data-transfer-bus": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-datastore": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-delegated-routing": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-dnslink": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-badger2": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-bitcask": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-crdt": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-dynamodb": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-flatfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-leveldb": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-measure": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-pebble": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-redis": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-s3": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-sql": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ds-swift": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-fetcher": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-filestore": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-fs-lock": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-graphsync": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-api": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-archived": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-blockstore": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-blocksutil": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-chunker": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-cmdkit": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-cmds": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-config": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-delay": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-ds-help": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-example-plugin": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-exchange-interface": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-exchange-offline": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-files": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-gateway": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-http-client": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-keystore": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-posinfo": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-pq": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-priv": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-provider": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-regression": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-routing": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipfs-util": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipld-cbor": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipld-eth": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipld-eth-import": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipld-format": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipld-git": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipld-legacy": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipld-zcash": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-ipns": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-jaeger-plugin": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-libp2p-dns-router": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-log": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-merkledag": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-metrics-interface": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-metrics-prometheus": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-mfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-namesys": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-path": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-peertaskqueue": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-pinning-service-http-client": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-poll-endpoint": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-qringbuf": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-sbs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-todocounter": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-unixfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-unixfsnode": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-verifcid": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "gomod": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "gs-priv": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "in-web-browsers": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "infra": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "interface-datastore": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "interface-go-ipfs-core": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "interop": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-blog": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-cluster": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-cluster-website": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-companion": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-docs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-ds-convert": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-gui": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-project.org": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-repository-template": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-update": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-website": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipfs-webui": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipget": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "ipld-explorer-components": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "iptb": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "iptb-plugins": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-blockstore-core": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-blockstore-datastore-adapter": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-core": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-datastore-core": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-datastore-fs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-datastore-idb": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-datastore-level": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-datastore-pubsub": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-datastore-s3": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-fs-pull-blob-store": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-hamt-sharding": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-idb-pull-blob-store": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfs-bitswap": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfs-block-service": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfs-http-response": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfs-interfaces": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfs-merkle-dag": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfs-repo": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfs-repo-migrations": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfs-unixfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfs-utils": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipfsd-ctl": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-ipns": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-level-pull-blob-store": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js.ipfs.io": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "lightning-storm": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "local-offline-collab": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "metrics": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "mobile-design-guidelines": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "newsletter": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "notes": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "npm-go-ipfs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "protons": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "public-gateway-checker": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "rainbow": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "roadmap": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "specs": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "tar-utils": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "team-mgmt": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "test-plans": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
   }
 }

--- a/github/ipfs/repository_file.json
+++ b/github/ipfs/repository_file.json
@@ -839,5 +839,35 @@
     ".github/workflows/stale.yml": {
       "content": "./.github/workflows/stale.yml"
     }
+  },
+  "download-ipfs-distribution-action": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "go-bitfield": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "js-dag-service": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "papers": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "pinning-services-api-spec": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
+  },
+  "start-ipfs-daemon-action": {
+    ".github/workflows/stale.yml": {
+      "content": "./.github/workflows/stale.yml"
+    }
   }
 }

--- a/scripts/add-need-author-input-label-to-all-repositories.sh
+++ b/scripts/add-need-author-input-label-to-all-repositories.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+root="$(realpath "$(dirname "$0")/..")"
+
+repository_file="$(jq '.' "$root/github/ipfs/repository_file.json")"
+
+while read repository; do
+  echo "Checking if $repository has need/author-input label already"
+  if ! gh api repos/ipfs/$repository/labels/need/author-input > /dev/null 2>&1; then
+    echo "Adding label need/author-input to $repository"
+    gh api -X POST repos/ipfs/$repository/labels -f name='need/author-input' -f color='ededed' -f description='Needs input from the original author' > /dev/null || true
+  fi
+done <<< "$(jq -r 'keys | .[]' "$root/github/ipfs/repository.json")"

--- a/scripts/add-stale-workflow-to-all-repositories.sh
+++ b/scripts/add-stale-workflow-to-all-repositories.sh
@@ -9,19 +9,21 @@ root="$(realpath "$(dirname "$0")/..")"
 repository_file="$(jq '.' "$root/github/ipfs/repository_file.json")"
 
 while read repository; do
-  echo "Checking if $repository has stale.yml already"
+  echo "Checking if $repository has stale worlflow already"
   has_stale="$(jq '.[$repository] | .[".github/workflows/stale.yml"] | . != null' --arg repository "$repository" <<< "$repository_file")"
   if [[ "$has_stale" == 'true' ]]; then
-    echo "stale.yml already exists in $repository, skipping"
+    echo "Stale workflow already exists in $repository, skipping"
   else
-    echo "Checking if $repository has either needs/author-input or hints/needs-author-input label"
-    if gh api repos/ipfs/$repository/labels/need/author-input > /dev/null 2>&1 || gh api repos/ipfs/$repository/labels/hint/needs-author-input > /dev/null 2>&1; then
-      echo "Found label in $repository, adding stale.yml"
+    echo "Checking if $repository has need/author-input label"
+    if gh api repos/ipfs/$repository/labels/need/author-input > /dev/null 2>&1; then
+      echo "Found label in $repository, adding stale workflow"
       repository_file="$(jq '.[$repository] +=  { ".github/workflows/stale.yml": { "content": "./.github/workflows/stale.yml" } }' --arg repository "$repository" <<< "$repository_file")"
     else
       echo "No label found in $repository, skipping"
     fi
   fi
+
+  echo $repository
 done <<< "$(jq -r 'keys | .[]' "$root/github/ipfs/repository.json")"
 
 echo "Saving new repository_file configuration"

--- a/scripts/ensure-stale-workflow-is-in-all-repos.sh
+++ b/scripts/ensure-stale-workflow-is-in-all-repos.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+root="$(realpath "$(dirname "$0")/..")"
+
+repository_file="$(jq '.' "$root/github/ipfs/repository_file.json")"
+
+while read repository; do
+  echo "Checking if $repository has stale.yml already"
+  has_stale="$(jq '.[$repository] | .[".github/workflows/stale.yml"] | . != null' --arg repository "$repository" <<< "$repository_file")"
+  if [[ "$has_stale" == 'true' ]]; then
+    echo "stale.yml already exists in $repository, skipping"
+  else
+    echo "Checking if $repository has either needs/author-input or hints/needs-author-input label"
+    if gh api repos/ipfs/$repository/labels/need/author-input > /dev/null 2>&1 || gh api repos/ipfs/$repository/labels/hint/needs-author-input > /dev/null 2>&1; then
+      echo "Found label in $repository, adding stale.yml"
+      repository_file="$(jq '.[$repository] +=  { ".github/workflows/stale.yml": { "content": "./.github/workflows/stale.yml" } }' --arg repository "$repository" <<< "$repository_file")"
+    else
+      echo "No label found in $repository, skipping"
+    fi
+  fi
+done <<< "$(jq -r 'keys | .[]' "$root/github/ipfs/repository.json")"
+
+echo "Saving new repository_file configuration"
+jq '.' <<< "$repository_file" > "$root/github/ipfs/repository_file.json"


### PR DESCRIPTION
This will distribute the [stale.yml](https://github.com/ipfs/github-mgmt/blob/e70e409243e4f8cda5f03634ba1770586c5128da/files/.github/workflows/stale.yml) workflow to [go-ipfs]() repository. 

I have verified that `go-ipfs` contains [`need/author-input` label](https://github.com/protocol/w3dt-stewards/issues/13). FYI, we'll be able to manage *labels* through GitHub Management once [data source for labels](https://github.com/integrations/terraform-provider-github/pull/1126) is added to the GitHub Terraform provider.