### PR TITLE
add self as collaborator to go-delegated-routing

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -1016,6 +1016,7 @@ repositories:
     collaborators:
       push:
         - web3-bot
+        - willscott
     description: Delegated routing, aka Reframe API, protocol implementation
     files:
       .github/workflows/stale.yml:


### PR DESCRIPTION
Have PRs, but can't tag reviewers.

Would make this as a PR I can tag reviewers against in this repo as requested by stewards, but can't per https://github.com/ipfs/github-mgmt/pull/30
