### PR TITLE
chore: add go-delegated-routing to repos accessible by Repos - Go team

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -1025,6 +1025,8 @@ repositories:
       admin:
         - w3dt-stewards
         - ipdx
+      push:
+        - Repos - Go
     visibility: public
   go-detect-race:
     collaborators:


### PR DESCRIPTION
`go-delegated-routing` is a Go repository so it should be accessible by `Repos - Go` team.