### PR TITLE
Create github-mgmt stewards team with access to github-mgmt

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -758,7 +758,7 @@ repositories:
         branch: master
         content: .github/workflows/stale.yml
       CODEOWNERS:
-        content: >
+        content: |
           # The ipdx team is responsible for GitHub Management maintenance
           * @ipfs/ipdx
 

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -749,25 +749,29 @@ repositories:
         - w3dt-stewards
         - ipdx
     visibility: public
-  github-mgmt:
+  github-mgmt: 
+    # WARN: push+ access here should be treated exactly as cautiosly as org admin role
     branch_protection:
       master: {}
-    collaborators:
-      admin:
-        - galargh
     files:
       .github/workflows/stale.yml:
         branch: master
         content: .github/workflows/stale.yml
       CODEOWNERS:
         content: >
-          *       @ipfs/ipdx
+          # The ipdx team is responsible for GitHub Management maintenance
+          * @ipfs/ipdx
+
+          # The org-admins team is responsible for triaging/reviewing configuration change requests
+          # TODO: uncomment once org-admins team has enough members
+          # /github/ipfs.yml @ipfs/org-admins
+    # ATTN: do not add teams with push+ access, use org-admins team membership instead
     teams:
       maintain:
         - ipdx
       push:
         - org-admins
-        - w3dt-stewards # consider removing once org-admins has enough members
+        - w3dt-stewards # TODO: remove once org-admins team has enough members
     visibility: public
   go-bitfield:
     collaborators:
@@ -4960,11 +4964,19 @@ teams:
         - laurentsenta
     parent_team_id: w3dt-stewards
     privacy: closed
-  org-admins: # created as a result of discussion in https://github.com/ipfs/github-mgmt/pull/30 
+  # NOTE: created to capture users with push+ access to github-mgmt repository
+  org-admins:
     create_default_maintainer: false
-    description: Users that should be allowed to perform any action an org admin can perform
+    description: Users that are effectively org admins
+    # WARN: membership here should be treated exactly as cautiosly as having an org admin role
+    # ATTN: members are expected to:
+    #  - be familiar with GitHub Management 
+    #  - be ready to triage/review org configuration change request in github-mgmt
     members:
+      maintainer:
+        - biglep
       member:
+        - aschmahmann
         - willscott
     privacy: closed
   w3dt-stewards:

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -4962,7 +4962,7 @@ teams:
     privacy: closed
   org-admins: # created as a result of discussion in https://github.com/ipfs/github-mgmt/pull/30 
     create_default_maintainer: false
-    description: Users with access to GitHub Management
+    description: Users that should be allowed to perform any action an org admin can perform
     members:
       member:
         - willscott

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -766,11 +766,11 @@ repositories:
           # The ipdx team is added here temporarily to witness use patterns in github-mgmt
           /github/ipfs.yml @ipfs/github-mgmt-stewards @ipfs/ipdx
     teams:
-      # ATTN: do not add teams with push+ access, use org-admins team membership instead
+      # ATTN: do not add teams with push+ access, use github-mgmt stewards team membership instead
       maintain:
         - ipdx # NOTE: ipdx are the creators of GitHub Management framework
       push:
-        - org-admins
+        - github-mgmt stewards
     visibility: public
   go-bitfield:
     collaborators:
@@ -4927,7 +4927,7 @@ teams:
     members:
       # WARN: membership here should be treated exactly as cautiosly as having an org admin role
       # ATTN: members are expected to:
-      #  - be familiar with GitHub Management 
+      #  - be familiar with GitHub Management
       #  - be ready to triage/review org configuration change request in github-mgmt
       maintainer:
         - aschmahmann

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -4978,6 +4978,8 @@ teams:
       member:
         - aschmahmann
         - willscott
+        - lidel
+        - guseggert
     privacy: closed
   w3dt-stewards:
     members:

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -764,8 +764,10 @@ repositories:
           *       @ipfs/ipdx
     teams:
       maintain:
-        - w3dt-stewards
         - ipdx
+      push:
+        - org-admins
+        - w3dt-stewards # consider removing once org-admins has enough members
     visibility: public
   go-bitfield:
     collaborators:
@@ -4957,6 +4959,13 @@ teams:
         - galargh
         - laurentsenta
     parent_team_id: w3dt-stewards
+    privacy: closed
+  org-admins: # created as a result of discussion in https://github.com/ipfs/github-mgmt/pull/30 
+    create_default_maintainer: false
+    description: Users with access to GitHub Management
+    members:
+      member:
+        - willscott
     privacy: closed
   w3dt-stewards:
     members:

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -763,15 +763,14 @@ repositories:
           * @ipfs/ipdx
 
           # The org-admins team is responsible for triaging/reviewing configuration change requests
-          # TODO: uncomment once org-admins team has enough members
-          # /github/ipfs.yml @ipfs/org-admins
+          # The ipdx team is added here temporarily to witness use patterns in github-mgmt
+          /github/ipfs.yml @ipfs/org-admins @ipfs/ipdx
     # ATTN: do not add teams with push+ access, use org-admins team membership instead
     teams:
       maintain:
         - ipdx
       push:
         - org-admins
-        - w3dt-stewards # TODO: remove once org-admins team has enough members
     visibility: public
   go-bitfield:
     collaborators:
@@ -4974,12 +4973,12 @@ teams:
     #  - be ready to triage/review org configuration change request in github-mgmt
     members:
       maintainer:
-        - biglep
-      member:
         - aschmahmann
-        - willscott
+        - biglep
         - lidel
+      member:
         - guseggert
+        - willscott
     privacy: closed
   w3dt-stewards:
     members:

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -749,7 +749,7 @@ repositories:
         - w3dt-stewards
         - ipdx
     visibility: public
-  github-mgmt: 
+  github-mgmt:
     # WARN: push+ access here should be treated exactly as cautiosly as org admin role
     branch_protection:
       master: {}

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -762,13 +762,13 @@ repositories:
           # The ipdx team is responsible for GitHub Management maintenance
           * @ipfs/ipdx
 
-          # The org-admins team is responsible for triaging/reviewing configuration change requests
+          # The github-mgmt stewards team is responsible for triaging/reviewing configuration change requests
           # The ipdx team is added here temporarily to witness use patterns in github-mgmt
-          /github/ipfs.yml @ipfs/org-admins @ipfs/ipdx
-    # ATTN: do not add teams with push+ access, use org-admins team membership instead
+          /github/ipfs.yml @ipfs/github-mgmt-stewards @ipfs/ipdx
     teams:
+      # ATTN: do not add teams with push+ access, use org-admins team membership instead
       maintain:
-        - ipdx
+        - ipdx # NOTE: ipdx are the creators of GitHub Management framework
       push:
         - org-admins
     visibility: public
@@ -4919,6 +4919,24 @@ teams:
         - TheDiscordian
         - yusefnapora
     privacy: closed
+  github-mgmt stewards:
+    # NOTE: created to capture users with push+ access to github-mgmt repository
+    #  using a team instead of direct collaborators because we want to reference it in the CODEOWNERS file
+    create_default_maintainer: false
+    description: Users that are effectively org admins
+    members:
+      # WARN: membership here should be treated exactly as cautiosly as having an org admin role
+      # ATTN: members are expected to:
+      #  - be familiar with GitHub Management 
+      #  - be ready to triage/review org configuration change request in github-mgmt
+      maintainer:
+        - aschmahmann
+        - biglep
+        - lidel
+      member:
+        - guseggert
+        - willscott
+    privacy: closed
   go-ipfs release:
     description: Who may cut a release of go-ipfs
     members:
@@ -4962,23 +4980,6 @@ teams:
         - galargh
         - laurentsenta
     parent_team_id: w3dt-stewards
-    privacy: closed
-  # NOTE: created to capture users with push+ access to github-mgmt repository
-  org-admins:
-    create_default_maintainer: false
-    description: Users that are effectively org admins
-    # WARN: membership here should be treated exactly as cautiosly as having an org admin role
-    # ATTN: members are expected to:
-    #  - be familiar with GitHub Management 
-    #  - be ready to triage/review org configuration change request in github-mgmt
-    members:
-      maintainer:
-        - aschmahmann
-        - biglep
-        - lidel
-      member:
-        - guseggert
-        - willscott
     privacy: closed
   w3dt-stewards:
     members:


### PR DESCRIPTION
This is a follow-up to https://github.com/ipfs/github-mgmt/pull/30

Related to https://github.com/ipfs/github-mgmt/issues/35#issuecomment-1204138300

It seems evident that we need a way to capture who should have write access to `github-mgmt`.

In this PR I create a new `github-mgmt stewards` team and give it write access to `github-mgmt`. I also revoke `w3dt-stewards` access, and I remove myself from admin collaborators because I get enough access from `ipdx` team membership.

The general idea is to build up `github-mgmt stewards` with users who are:
- familiar with GitHub Management
- trusted within the org
- want/need to be able to triage/merge PRs