### PR TITLE
Fixes sync workflow and syncs YAML with GH

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -192,6 +192,7 @@ members:
     - protocollabsit-readonly
     - ratoshniuk
     - raulk
+    - reidlw
     - requilence
     - ribasushi
     - richardschneider
@@ -4876,6 +4877,7 @@ teams:
         - laurentsenta
         - marten-seemann
         - petar
+        - reidlw
     privacy: closed
   website-deployers:
     description: We can deploy the websites

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -192,7 +192,6 @@ members:
     - protocollabsit-readonly
     - ratoshniuk
     - raulk
-    - reidlw
     - requilence
     - ribasushi
     - richardschneider
@@ -747,8 +746,7 @@ repositories:
           /github/ipfs.yml @ipfs/github-mgmt-stewards @ipfs/ipdx
     teams:
       # ATTN: do not add teams with push+ access, use github-mgmt stewards team membership instead
-      maintain:
-        - ipdx # NOTE: ipdx are the creators of GitHub Management framework
+      maintain: []
       push:
         - github-mgmt stewards
     visibility: public
@@ -1003,6 +1001,7 @@ repositories:
         - ipdx
       push:
         - Repos - Go
+        - Merge - Go
     visibility: public
   go-detect-race:
     collaborators:
@@ -1661,6 +1660,7 @@ repositories:
         - Stebalien
       push:
         - web3-bot
+    description: Demo plugin for Kubo IPFS daemon
     files:
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
@@ -2777,14 +2777,13 @@ repositories:
         - cwaring
         - johnnymatthews
       maintain:
-        - BlocksOnAChain
         - TheDiscordian
         - hugomrdias
         - walkerlj0
         - yusefnapora
-        - dannys03
+        - DannyS03
+        - jennijuju
       push:
-        - Annamarie2019
         - TMoMoreau
         - gmasgras
         - johndmulhausen
@@ -3602,6 +3601,23 @@ repositories:
         - Repos - JavaScript
         - admin
     visibility: public
+  js-kubo-rpc-client:
+    collaborators:
+      admin:
+        - SgtPooki
+      push:
+        - web3-bot
+    description: A client library for the Kubo RPC API
+    teams:
+      admin: []
+      pull: []
+      push: []
+    topics:
+      - http-client
+      - ipfs
+      - kubo
+      - rpc-client
+    visibility: public
   js-level-pull-blob-store:
     collaborators:
       push:
@@ -3621,21 +3637,18 @@ repositories:
         - JS Core Team
         - Repos - JavaScript
     visibility: public
-  js.ipfs.io:
+  js.ipfs.tech:
     branch_protection:
       master: {}
     collaborators:
       push:
         - web3-bot
     description: The Website for the JavaScript implementation of the IPFS protocol
-    files:
-      .github/workflows/stale.yml:
-        content: .github/workflows/stale.yml
     teams:
       admin:
         - admin
-        - w3dt-stewards
         - ipdx
+        - w3dt-stewards
       maintain:
         - Maintainers
       push:
@@ -4032,32 +4045,6 @@ repositories:
         - ipdx
       maintain:
         - TestGround
-    visibility: public
-  js-kubo-rpc-client:
-    branch_protection:
-      master: {}
-      release: {}
-      release-*: {}
-    collaborators:
-      push:
-        - web3-bot
-    description: A client library for the Kubo RPC API
-    teams:
-      admin:
-        - admin
-        - w3dt-stewards
-        - ipdx
-      pull:
-        - contributors
-      push:
-        - Maintainers
-        - Merge - Go
-        - Repos - Go
-    topics:
-      - ipfs
-      - http-client
-      - rpc-client
-      - kubo
     visibility: public
 teams:
   CI:
@@ -4807,8 +4794,8 @@ teams:
       #  - be ready to triage/review org configuration change request in github-mgmt
       maintainer:
         - aschmahmann
-        - biglep
         - lidel
+        - BigLep
       member:
         - guseggert
         - willscott
@@ -4875,7 +4862,6 @@ teams:
         - laurentsenta
         - marten-seemann
         - petar
-        - reidlw
     privacy: closed
   website-deployers:
     description: We can deploy the websites
@@ -4903,8 +4889,6 @@ teams:
         - jacobheun
         - lidel
       member:
-        - Gozala
         - achingbrain
-        - eshon
-        - pooja
+        - SgtPooki
     privacy: closed

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -746,7 +746,8 @@ repositories:
           /github/ipfs.yml @ipfs/github-mgmt-stewards @ipfs/ipdx
     teams:
       # ATTN: do not add teams with push+ access, use github-mgmt stewards team membership instead
-      maintain: []
+      maintain:
+        - ipdx # NOTE: ipdx are the creators of GitHub Management framework
       push:
         - github-mgmt stewards
     visibility: public
@@ -3602,21 +3603,30 @@ repositories:
         - admin
     visibility: public
   js-kubo-rpc-client:
+    branch_protection:
+      master: {}
+      release: {}
+      release-*: {}
     collaborators:
-      admin:
-        - SgtPooki
       push:
         - web3-bot
     description: A client library for the Kubo RPC API
     teams:
-      admin: []
-      pull: []
-      push: []
+      admin:
+        - admin
+        - w3dt-stewards
+        - ipdx
+      pull:
+        - contributors
+      push:
+        - Maintainers
+        - Merge - Go
+        - Repos - Go
     topics:
-      - http-client
       - ipfs
-      - kubo
+      - http-client
       - rpc-client
+      - kubo
     visibility: public
   js-level-pull-blob-store:
     collaborators:
@@ -3644,6 +3654,10 @@ repositories:
       push:
         - web3-bot
     description: The Website for the JavaScript implementation of the IPFS protocol
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
+        overwrite_on_create: true
     teams:
       admin:
         - admin

--- a/scripts/src/github.ts
+++ b/scripts/src/github.ts
@@ -190,13 +190,26 @@ export class GitHub {
   async getRepositoryFile(repository: string, path: string) {
     core.info(`Checking if ${repository}/${path} exists...`)
     try {
-      return (
-        await this.client.repos.getContent({
+      const repo = (
+        await this.client.repos.get({
           owner: env.GITHUB_ORG,
-          repo: repository,
-          path
+          repo: repository
         })
-      ).data as {path: string; url: string}
+      ).data
+      if (repo.owner.login === env.GITHUB_ORG && repo.name === repository) {
+        return (
+          await this.client.repos.getContent({
+            owner: env.GITHUB_ORG,
+            repo: repository,
+            path
+          })
+        ).data as {path: string; url: string}
+      } else {
+        core.debug(
+          `${env.GITHUB_ORG}/${repository} has moved to ${repo.owner.login}/${repo.name}`
+        )
+        return undefined
+      }
     } catch (e) {
       core.debug(JSON.stringify(e))
       return undefined


### PR DESCRIPTION
I noticed https://github.com/ipfs/github-mgmt/pull/43 wasn't properly applied. That's because it tried to create a repository that already existed. To pull existing resources under GitHub Management, one has to run the [Sync workflow](https://github.com/ipfs/github-mgmt/actions/workflows/sync.yml) and merge the PR that it creates. That's what I did here. FYI, we want to put sync runs on weekly schedule soon - https://github.com/protocol/github-mgmt-template/pull/56

One more thing that I did here was to fix the sync script itself (https://github.com/ipfs/github-mgmt/commit/715f4b3a93272b9e4f3e10c07fa7991259503ccf). As it turns out it didn't handle files during repo renames properly. 

Finally, I did restore the changes that were supposed to be applied/preserved:
- repo config from https://github.com/ipfs/github-mgmt/pull/43
- stale workflow in `js.ipfs.io` -> `js.ipfs.tech`
- `reidlw` access to org/w3dt-stewards team