### PR TITLE
chore: add ipfs/go-ipfs-redirects-file

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -2078,6 +2078,25 @@ repositories:
         - Merge - Go
         - Repos - Go
     visibility: public
+  go-ipfs-redirects-file:
+      archived: false
+      collaborators:
+        admin:
+          - lidel
+        maintain:
+          - justincjohnson
+        push:
+          - web3-bot
+      default_branch: main
+      description: IPFS Web Gateway _redirects file format parser
+      teams:
+        pull:
+          - admin
+          - w3dt-stewards
+      visibility: public    
+      files:
+        .github/workflows/stale.yml:
+          content: .github/workflows/stale.yml
   go-ipfs-regression:
     archived: false
     collaborators:

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -2079,24 +2079,24 @@ repositories:
         - Repos - Go
     visibility: public
   go-ipfs-redirects-file:
-      archived: false
-      collaborators:
-        admin:
-          - lidel
-        maintain:
-          - justincjohnson
-        push:
-          - web3-bot
-      default_branch: main
-      description: IPFS Web Gateway _redirects file format parser
-      teams:
-        pull:
-          - admin
-          - w3dt-stewards
-      visibility: public    
-      files:
-        .github/workflows/stale.yml:
-          content: .github/workflows/stale.yml
+    archived: false
+    collaborators:
+      admin:
+        - lidel
+      maintain:
+        - justincjohnson
+      push:
+        - web3-bot
+    default_branch: main
+    description: IPFS Web Gateway _redirects file format parser
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
+    teams:
+      pull:
+        - admin
+        - w3dt-stewards
+    visibility: public
   go-ipfs-regression:
     archived: false
     collaborators:


### PR DESCRIPTION
Moved to main org because it is critical part of gateway code, and should be maintained by the same team as Kubo itself.