### PR TITLE
added reidlw to w3dt-stewards

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -184,6 +184,7 @@ members:
     - Prtfw
     - ratoshniuk
     - raulk
+    - reidlw
     - requilence
     - ribasushi
     - RichardLitt
@@ -5230,6 +5231,7 @@ teams:
         - MarcoPolo
         - marten-seemann
         - petar
+        - reidlw
         - SgtPooki
     privacy: closed
   website-deployers:


### PR DESCRIPTION
adding myself to w3dt-stewards. I tried to do this a few weeks ago, but apparently didn't accept an invite somewhere and so the change was reverted. Any pointers to where to find the invite would be appreciated so it doesn't happen again
