### PR TITLE
feat: start managing all branch protection props through github-mgmt

### DIFF
--- a/terraform/resources_override.tf
+++ b/terraform/resources_override.tf
@@ -24,22 +24,6 @@ resource "github_repository" "this" {
   }
 }
 
-resource "github_branch_protection" "this" {
-  lifecycle {
-    ignore_changes = [
-      allows_deletions,
-      allows_force_pushes,
-      enforce_admins,
-      push_restrictions,
-      require_conversation_resolution,
-      require_signed_commits,
-      required_linear_history,
-      required_pull_request_reviews,
-      required_status_checks,
-    ]
-  }
-}
-
 resource "github_repository_file" "this" {
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
After this PR is merged, we'll be able to start modifying all branch protection props through GitHub Management.

We'll run sync after the merge to pull in all the props for existing branch protection rules.