### PR TITLE
New PL writer requesting ipfs-docs permissions

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -3403,6 +3403,7 @@ repositories:
         - johnnymatthews
       maintain:
         - DannyS03
+        - ElPaisano
         - hugomrdias
         - jennijuju
         - TheDiscordian


### PR DESCRIPTION
Adds @ElPaisano as a maintainer to the ipfs-docs repo

<!-- Please explain the reason for this change. -->

I'm a new LTC tech writer with the PLN, and I need to be able to merge PRs in the ipfs docs repo. Hopefully, I created this request correctly. Thank you!
