### PR TITLE
create kubo-maintainers team

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -5621,6 +5621,19 @@ teams:
         - jimpick
         - vasco-santos
     privacy: closed
+  kubo maintainers:
+    description: Kubo Maintainers
+    members:
+      maintainer:
+        - aschmahmann
+        - BigLep
+        - lidel
+      member:
+        - ajnavarro
+        - guseggert
+        - hacdias
+        - Jorropo
+    privacy: closed
   Maintainers:
     description: People with Maintainer access to all repositories
     members:


### PR DESCRIPTION
### Summary
Create kubo-maintainers team which will collect all the Kubo maintainers.

### Why do you need this?
We want to have a way of reaching kubo maintainers on GitHub. With this, this could be achieved by mentioning @ipfs/kubo-maintainers.

### What else do we need to know?
n/a

**DRI:** myself & @ajnavarro

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
