### PR TITLE
Remove petar from w3dt-steards team

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -5987,7 +5987,6 @@ teams:
         - laurentsenta
         - MarcoPolo
         - marten-seemann
-        - petar
         - SgtPooki
         - whizzzkid
         - wilkyr31d


### PR DESCRIPTION
### Summary
Remove petar from w3dt-steards team

### Why do you need this?
He is no longer doing stewardship work in this org.

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
