### PR TITLE
chore: archive inactive repos

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -3705,7 +3705,7 @@ repositories:
       - ipfs
     visibility: public
   ipfs-project.org:
-    archived: false
+    archived: true
     collaborators:
       admin:
         - andyschwab
@@ -4044,7 +4044,7 @@ repositories:
         - w3dt-stewards
     visibility: public
   js-core:
-    archived: false
+    archived: true
     collaborators:
       admin:
         - alanshaw
@@ -4955,7 +4955,7 @@ repositories:
         - comms
     visibility: public
   notes:
-    archived: false
+    archived: true
     collaborators:
       push:
         - jsoares
@@ -5293,7 +5293,7 @@ repositories:
         - Repos - Go
     visibility: public
   team-mgmt:
-    archived: false
+    archived: true
     collaborators:
       push:
         - web3-bot


### PR DESCRIPTION
### Summary

As discussed with @discordian, these repos are inactive and could be archived.

The `notes` repo was approved by Lidel for archival 

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
