### PR TITLE
Add @2color as docs admin

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -3650,12 +3650,12 @@ repositories:
       admin:
         - cwaring
         - johnnymatthews
+        - 2color
       maintain:
         - ElPaisano
         - hugomrdias
         - TheDiscordian
       push:
-        - 2color
         - gmasgras
         - mishmosh
         - TMoMoreau

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -3648,9 +3648,9 @@ repositories:
           strict: false
     collaborators:
       admin:
+        - 2color
         - cwaring
         - johnnymatthews
-        - 2color
       maintain:
         - ElPaisano
         - hugomrdias


### PR DESCRIPTION
### Summary

Give myself admin access to the docs repo.

### Why do you need this?

To integrate pipeline for quicker preview deployments 

### What else do we need to know?

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
