### PR TITLE
do not enforce admins on default branches

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -1662,7 +1662,7 @@ repositories:
         allows_deletions: false
         allows_force_pushes: false
         blocks_creations: false
-        enforce_admins: true
+        enforce_admins: false
         lock_branch: false
         push_restrictions:
           - MDQ6VGVhbTMzNjQxMDI=
@@ -3195,7 +3195,7 @@ repositories:
         allows_deletions: false
         allows_force_pushes: false
         blocks_creations: false
-        enforce_admins: true
+        enforce_admins: false
         lock_branch: false
         push_restrictions:
           - MDQ6VGVhbTMzNjQxMDI=
@@ -4480,6 +4480,9 @@ repositories:
         - achingbrain
     default_branch: main
     description: Import/export car files from Helia
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4497,7 +4500,7 @@ repositories:
         allows_deletions: false
         allows_force_pushes: false
         blocks_creations: false
-        enforce_admins: true
+        enforce_admins: false
         lock_branch: false
         require_conversation_resolution: false
         require_signed_commits: false
@@ -4627,6 +4630,9 @@ repositories:
         - web3-bot
     default_branch: main
     description: The Routing V1 HTTP API powered by Helia
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/scripts/src/actions/do-not-enforce-admins.ts
+++ b/scripts/src/actions/do-not-enforce-admins.ts
@@ -1,0 +1,37 @@
+import {Config} from '../yaml/config'
+import {RepositoryBranchProtectionRule} from '../resources/repository-branch-protection-rule'
+import {Repository} from '../resources/repository'
+import * as core from '@actions/core'
+
+export async function doNotEnforceAdmins(
+  repositoryAndRuleFilter: (
+    repository: Repository,
+    branchProtectionRule: RepositoryBranchProtectionRule
+  ) => boolean = () => true
+): Promise<void> {
+  const config = Config.FromPath()
+
+  const repositories = config.getResources(Repository).filter(r => !r.archived)
+  const rules = config
+    .getResources(RepositoryBranchProtectionRule)
+    .filter(r => r.enforce_admins)
+    .filter(rule => {
+      const repository = repositories.find(
+        repo => repo.name === rule.repository
+      )
+      if (!repository) {
+        return false
+      }
+      return repositoryAndRuleFilter(repository, rule)
+    })
+
+  for (const rule of rules) {
+    core.info(
+      `Disabling enforce_admins for ${rule.repository}@${rule.pattern} repository`
+    )
+    rule.enforce_admins = false
+    config.addResource(rule)
+  }
+
+  config.save()
+}

--- a/scripts/src/actions/fix-yaml-config.ts
+++ b/scripts/src/actions/fix-yaml-config.ts
@@ -37,6 +37,8 @@ setPropertyInAllRepos(
 )
 doNotEnforceAdmins(
   (repository: Repository, rule: RepositoryBranchProtectionRule) =>
-    isInitialised(repository) && repository.default_branch !== undefined && globToRegex(rule.pattern).test(repository.default_branch)
+    isInitialised(repository) &&
+    repository.default_branch !== undefined &&
+    globToRegex(rule.pattern).test(repository.default_branch)
 )
 format()

--- a/scripts/src/actions/fix-yaml-config.ts
+++ b/scripts/src/actions/fix-yaml-config.ts
@@ -1,5 +1,8 @@
 import 'reflect-metadata'
 import {Repository} from '../resources/repository'
+import {RepositoryBranchProtectionRule} from '../resources/repository-branch-protection-rule'
+import {globToRegex} from '../utils'
+import {doNotEnforceAdmins} from './do-not-enforce-admins'
 import {addFileToAllRepos} from './shared/add-file-to-all-repos'
 import {format} from './shared/format'
 import {setPropertyInAllRepos} from './shared/set-property-in-all-repos'
@@ -31,5 +34,9 @@ setPropertyInAllRepos(
   'secret_scanning_push_protection',
   true,
   r => isInitialised(r) && isPublic(r)
+)
+doNotEnforceAdmins(
+  (repository: Repository, rule: RepositoryBranchProtectionRule) =>
+    isInitialised(repository) && repository.default_branch !== undefined && globToRegex(rule.pattern).test(repository.default_branch)
 )
 format()

--- a/scripts/src/utils.ts
+++ b/scripts/src/utils.ts
@@ -15,3 +15,26 @@ export function yamlify(value: any): YAML.ParsedNode {
   }
   return node
 }
+
+export function globToRegex(globPattern: string): RegExp {
+  const regexPattern = globPattern
+    .split('')
+    .map(char => {
+      if (char === '*') {
+        return '.*'
+      } else if (char === '?') {
+        return '.'
+      } else if (
+        ['.', '\\', '+', '(', ')', '[', ']', '{', '}', '|', '^', '$'].includes(
+          char
+        )
+      ) {
+        return `\\${char}`
+      } else {
+        return char
+      }
+    })
+    .join('')
+
+  return new RegExp(`^${regexPattern}$`)
+}


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->
This PR ensures that we do not enforce branch protections on admins on default branches.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->
When we enforce branch protections on admins on default branches, we can't perform some automation. In particular, using GitHub Management `files` needs GitHub Management app to be able to circumvent branch protections on the default branch. Another example would be JS release automation in some helia repos. 

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->
This PR adds a GitHub Management `fix` script that ensures we won't enforce branch protections on admins on default branches in the future.

https://filecoinproject.slack.com/archives/C046HDAHA13/p1681285090683789

**DRI:** myself, @achingbrain
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
