### PR TITLE
Remove TestGround

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -5533,8 +5533,6 @@ repositories:
       admin:
         - ipdx
         - w3dt-stewards
-      maintain:
-        - TestGround
     visibility: public
 teams:
   admin:
@@ -6292,16 +6290,6 @@ teams:
       member:
         - achingbrain
         - yiannisbot
-    privacy: closed
-  TestGround:
-    members:
-      maintainer:
-        - daviddias
-      member:
-        - hacdias
-        - jimpick
-        - nonsense
-        - raulk
     privacy: closed
   w3dt-stewards:
     members:


### PR DESCRIPTION
### Summary

The TestGround team no longer exists and is now maintained by a different group of people in a different organization (https://github.com/testground).

We should perhaps also consider archiving https://github.com/ipfs/test-plans, since it is no longer used.

### Why do you need this?

Clean up.

### What else do we need to know?

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
