### PR TITLE
add w3dt-stewards to gateway-conformance admins

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -922,6 +922,7 @@ repositories:
     teams:
       admin:
         - ipdx
+        - w3dt-stewards
     visibility: public
   gh-issue-form-test:
     archived: false


### PR DESCRIPTION
### Summary
add w3dt-stewards to gateway-conformance admins

### Why do you need this?

### What else do we need to know?

**DRI:** @galargh 

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
