### PR TITLE
ci: remove hacdias from GUI group

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -8843,13 +8843,12 @@ teams:
         - Jorropo
     privacy: secret
   gui-dev:
-    description: GUI Developers and engineers
+    description: GUI Developers and Engineers
     members:
       maintainer:
         - lidel
         - SgtPooki
       member:
-        - hacdias
         - whizzzkid
     parent_team_id: WG GUI/UX
     privacy: closed


### PR DESCRIPTION
### Summary

Remove myself from the GUI group.

### Why do you need this?

I don't actively work on the GUI projects, but get notified about every single PR and issue. Can be distracting.

### What else do we need to know?

**DRI:** myself

cc @lidel 

### Reviewer's Checklist

- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
