### PR TITLE
Unarchive rainbow and broaden access

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -8315,8 +8315,8 @@ repositories:
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
-    secret_scanning_push_protection: false
-    secret_scanning: false
+    secret_scanning_push_protection: true
+    secret_scanning: true
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -8279,8 +8279,8 @@ repositories:
   rainbow:
     advanced_security: false
     allow_update_branch: false
-    archived: true
-    default_branch: master
+    archived: false
+    default_branch: main
     description: "EXPERIMENT: A standalone ipfs gateway"
     files:
       .github/workflows/stale.yml:
@@ -8319,6 +8319,16 @@ repositories:
     secret_scanning: false
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    teams:
+      admin:
+        - admin
+      push:
+        - ipdx
+        - w3dt-stewards
+    topics:
+      - http
+      - ipfs-gateway
+      - ipfs
     visibility: public
   roadmap:
     advanced_security: false

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -8280,6 +8280,9 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
+    collaborators:
+      push:
+        - web3-bot
     default_branch: main
     description: "EXPERIMENT: A standalone ipfs gateway"
     files:


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

Unarchiving [rainbow](https://github.com/ipfs/rainbow) and giving some standard groups access.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

The repo was archived as mostly unusable, now with boxo this is much easier! Want to experiment and see how it goes.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** @aschmahmann 
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
