### PR TITLE
Add Daniel as admin to js.ipfs.tech and Helia

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -5293,8 +5293,8 @@ repositories:
     archived: false
     collaborators:
       admin:
-        - achingbrain
         - 2color
+        - achingbrain
     default_branch: main
     description: An implementation of IPFS in JavaScript
     files:
@@ -7672,10 +7672,10 @@ repositories:
             - fleek/build
           strict: false
     collaborators:
-      triage:
-        - ElPaisano
       admin:
         - 2color
+      triage:
+        - ElPaisano
     default_branch: master
     description: The Website for the JavaScript implementation of the IPFS protocol
     files:

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -5294,6 +5294,7 @@ repositories:
     collaborators:
       admin:
         - achingbrain
+        - 2color
     default_branch: main
     description: An implementation of IPFS in JavaScript
     files:
@@ -7673,6 +7674,8 @@ repositories:
     collaborators:
       triage:
         - ElPaisano
+      admin:
+        - 2color
     default_branch: master
     description: The Website for the JavaScript implementation of the IPFS protocol
     files:


### PR DESCRIPTION
### Summary

I'm updating https://js.ipfs.tech/ to be redirected to the Helia website (helia.io). This requires access to the GitHub page settings which are only available to repo admins.

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
