### PR TITLE
Give Go Core Team push access to `go-ds-pebble`

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -2463,6 +2463,7 @@ repositories:
         - Kubuxu
         - raulk
       push:
+        - Go Core Team
         - web3-bot
     default_branch: master
     description: A datastore implementation backed by

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -427,11 +427,14 @@ repositories:
         - marshall
     default_branch: main
     description: is IPFS actually InterPlanetary yet?
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
-    secret_scanning_push_protection: false
-    secret_scanning: false
+    secret_scanning_push_protection: true
+    secret_scanning: true
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
@@ -906,6 +909,9 @@ repositories:
         - 2color
     default_branch: main
     description: IPFS DApps Working Group
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: true
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -7153,6 +7159,9 @@ repositories:
         - web3-bot
     default_branch: main
     description: JavaScript implementation of Bitswap 'data exchange' protocol used by IPFS
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -8417,11 +8426,14 @@ repositories:
         required_linear_history: false
     default_branch: master
     description: Shell library to test your Unix tools like Git does
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
-    secret_scanning_push_protection: false
-    secret_scanning: false
+    secret_scanning_push_protection: true
+    secret_scanning: true
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
@@ -8741,6 +8753,9 @@ repositories:
       admin:
         - damedoteth
     default_branch: main
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE


### PR DESCRIPTION
### Summary
Give Go Core Team push access to `go-ds-pebble`

### Why do you need this?
To update Pebble dependency.

### What else do we need to know?
Nada.

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
