### PR TITLE
Temp. grant admin to lidel to facilitate repo migration

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -160,7 +160,6 @@ members:
     - kylehuntsman
     - laurentsenta
     - leshokunin
-    - lidel
     - listenaddress
     - litzenberger
     - locotorp

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -18,6 +18,9 @@ members:
     # 1. co-founder of [IPDX](https://ipdx.co), and IPDX is contracted to look after GitHub for this organization.
     # 2. Multiple years of experience managing GitHub organizations of open source projects, including this org.
     - galargh
+    # Why @lidel
+    # Need admin to finish https://github.com/ipfs-shipyard/helia-service-worker-gateway/issues/80
+    - lidel
   member:
     - 1015bit
     - 2color


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

I want to finish https://github.com/ipfs-shipyard/service-worker-gateway/issues/80 but Cloudflare Pages introduced in https://github.com/ipfs-shipyard/service-worker-gateway/issues/244 do not support switching repos, so it is likely integration will break after a move.

If that happens, I need to recreate the project and grant permissions, and afaik only admin can do it, granting me temp. admin is the simplest way to finish migration.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
