### PR TITLE
Create new go-test repo

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -3922,6 +3922,9 @@ repositories:
       admin:
         - 2color
     default_branch: master
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -3246,6 +3246,60 @@ repositories:
     visibility: public
   go-sbs:
     archived: true
+  go-test:
+    advanced_security: false
+    allow_merge_commit: true
+    allow_rebase_merge: true
+    allow_squash_merge: true
+    allow_update_branch: false
+    archived: false
+    branch_protection:
+      main:
+        allows_deletions: false
+        allows_force_pushes: false
+        blocks_creations: false
+        enforce_admins: false
+        lock_branch: false
+        require_conversation_resolution: false
+        require_signed_commits: false
+        required_linear_history: false
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          require_code_owner_reviews: false
+          required_approving_review_count: 0
+          restrict_dismissals: false
+        required_status_checks:
+          contexts:
+            - go-check / All
+            - go-test / ubuntu (go this)
+          strict: false
+    collaborators:
+      push:
+        - web3-bot
+    default_branch: main
+    delete_branch_on_merge: true
+    description: ":test_tube: Testing utilty library"
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
+    has_discussions: false
+    merge_commit_message: PR_TITLE
+    merge_commit_title: MERGE_MESSAGE
+    secret_scanning_push_protection: true
+    secret_scanning: true
+    squash_merge_commit_message: COMMIT_MESSAGES
+    squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    teams:
+      admin:
+        - admin
+        - ipdx
+        - kubo maintainers
+        - w3dt-stewards
+      pull:
+        - github-mgmt stewards
+    topics:
+      - testing
+    visibility: public
   go-todocounter:
     advanced_security: false
     allow_update_branch: false


### PR DESCRIPTION
### Summary
Create new go-test repo.

### Why do you need this?
Contains test utility code that is common across multiple projects. The repo provides a place to put common (not project specific) test code to make it easier to find and reuse.

### What else do we need to know?
Since this is a new repo, it would be good for maintainers to bypass requiring reviews before merging as there will likely be frequent additions early on.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
