### PR TITLE
chore: add hsanjuan to kubo maintainers

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -3227,6 +3227,8 @@ repositories:
         - admin
         - ipdx
         - kubo maintainers
+      maintain:
+        - shipyard        
         - w3dt-stewards
       pull:
         - github-mgmt stewards
@@ -3868,6 +3870,8 @@ repositories:
       admin:
         - admin
         - kubo maintainers
+      maintain:
+        - shipyard        
     topics:
       - ipfs
     visibility: public
@@ -6390,6 +6394,7 @@ teams:
       member:
         - aschmahmann
         - gammazero
+        - hsanjuan
     privacy: closed
   Maintainers:
     description: People with Maintainer access to all repositories

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -3228,7 +3228,7 @@ repositories:
         - ipdx
         - kubo maintainers
       maintain:
-        - shipyard        
+        - shipyard
         - w3dt-stewards
       pull:
         - github-mgmt stewards
@@ -3871,7 +3871,7 @@ repositories:
         - admin
         - kubo maintainers
       maintain:
-        - shipyard        
+        - shipyard
     topics:
       - ipfs
     visibility: public


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

- adding @hsanjuan to @ipfs/kubo-maintainers  as well 
- adding @ipfs/shipyard as maintainer in places where we only has @ipfs/kubo-maintainers  and lowering permissions of wider  @ipfs/shipyard group  from "admin" to "maintain"

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
