### PR TITLE
Add guillaumemichel to kubo maintainers

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -6380,6 +6380,7 @@ teams:
         - aschmahmann
         - gammazero
         - hsanjuan
+        - guillaumemichel
     privacy: closed
   Maintainers:
     description: People with Maintainer access to all repositories

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -6379,8 +6379,8 @@ teams:
       member:
         - aschmahmann
         - gammazero
-        - hsanjuan
         - guillaumemichel
+        - hsanjuan
     privacy: closed
   Maintainers:
     description: People with Maintainer access to all repositories


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

Adding @guillaumemichel  to @ipfs/kubo-maintainers 

### Why do you need this?

Gui will be spending more time contributing to IPFS and Go Triage 

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
