### PR TITLE
fix: let specs reviewers merge specs PRs

### DIFF
--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -972,8 +972,6 @@ repositories:
         require_signed_commits: false
         required_linear_history: false
     collaborators:
-      admin:
-        - mishmosh
       maintain:
         - amanda-agency-undone
         - D3AS8A
@@ -3507,8 +3505,6 @@ repositories:
         require_signed_commits: false
         required_linear_history: false
     collaborators:
-      admin:
-        - mishmosh
       push:
         - damedoteth
         - darobin
@@ -3849,8 +3845,6 @@ repositories:
             - build
           strict: false
     collaborators:
-      admin:
-        - mishmosh
       maintain:
         - bumblefudge
       push:
@@ -4072,7 +4066,6 @@ repositories:
     collaborators:
       admin:
         - cwaring
-        - mishmosh
       push:
         - web3-bot
     default_branch: main

--- a/github/ipfs.yml
+++ b/github/ipfs.yml
@@ -5690,6 +5690,7 @@ repositories:
         push_restrictions:
           - ipfs/admin
           - ipfs/docs
+          - ipfs/specs-stewards
         require_conversation_resolution: false
         require_signed_commits: false
         required_linear_history: false
@@ -5704,6 +5705,7 @@ repositories:
             push_allowances:
               - ipfs/admin
               - ipfs/docs
+              - ipfs/specs-stewards
     collaborators:
       maintain:
         - bumblefudge
@@ -6003,6 +6005,9 @@ teams:
         - lidel
       member:
         - achingbrain
+        - bumblefudge
+        - darobin
+        - mishmosh
     privacy: closed
   github-mgmt stewards:
     # Notes:
@@ -6193,6 +6198,8 @@ teams:
         - lidel
       member:
         - achingbrain
+        - bumblefudge
+        - mishmosh
         - Stebalien
         - yiannisbot
     privacy: closed


### PR DESCRIPTION
Specs Stewards had write on `ipfs/specs` but sat outside the `main` push allowlist, so its maintainers could review and not merge; this adds the team to the allowlist and puts @bumblefudge, @darobin and @mishmosh on the teams that reach it.

Also deduplicates permissions of @mishmosh where the `devrel` team already grants `admin`. 

- Closes #266